### PR TITLE
Major update/rewrite

### DIFF
--- a/src/binning/generic.jl
+++ b/src/binning/generic.jl
@@ -1,100 +1,77 @@
 abstract type AbstractBinningAlgorithm end
 
-struct Bin{T<:Real}
+mutable struct Bin{T<:Real}
     """Number of samples."""
-    nsamples::Ref{Int}
+    nsamples::Int
     """Sum of predictions."""
-    prediction_sum::Vector{T}
-    """Counts of labels."""
-    label_counts::Vector{Int}
+    sum_predictions::Vector{T}
+    """Counts of targets."""
+    counts_targets::Vector{Int}
 
-    function Bin{T}(nsamples::Ref{Int}, prediction_sum::Vector{T},
-                    label_counts::Vector{Int}) where T
-        nsamples[] ≥ 0 || throw(ArgumentError("the number of samples must be non-negative"))
-        nclasses = length(prediction_sum)
+    function Bin{T}(nsamples::Int, sum_predictions::Vector{T},
+                    counts_targets::Vector{Int}) where {T}
+        nsamples ≥ 0 || throw(ArgumentError("the number of samples must be non-negative"))
+        nclasses = length(sum_predictions)
         nclasses > 1 || throw(ArgumentError("the number of classes must be greater than 1"))
-        nclasses == length(label_counts) ||
+        nclasses == length(counts_targets) ||
             throw(DimensionMismatch("the number of predicted classes has to be equal to the number of classes"))
 
-        new{T}(nsamples, prediction_sum, label_counts)
+        new{T}(nsamples, sum_predictions, counts_targets)
     end
 end
 
-Bin(nsamples::Ref{Int}, prediction_sum::Vector{<:Real}, label_counts::Vector{Int}) =
-    Bin{eltype(prediction_sum)}(nsamples, prediction_sum, label_counts)
+Bin(nsamples::Int, sum_predictions::Vector{<:Real}, counts_targets::Vector{Int}) =
+    Bin{eltype(sum_predictions)}(nsamples, sum_predictions, counts_targets)
 
-"""
-    Bin(predictions, labels)
-
-Create bin of `predictions` and corresponding `labels`.
-"""
-function Bin(predictions::AbstractMatrix{<:Real}, labels::AbstractVector{<:Integer})
-    # check arguments
-    nclasses, nsamples = check_size(predictions, labels)
-
-    # compute sum of predictions
-    prediction_sum = vec(sum(predictions, dims=2))
-
-    # compute counts of labels
-    label_counts = counts(labels, 1:nclasses)
-
-    Bin(Ref(nsamples), prediction_sum, label_counts)
+function Bin(nsamples::Int, sum_predictions::AbstractVector{<:Real},
+             counts_targets::Vector{Int})
+    Bin(nsamples, convert(Vector, sum_predictions), counts_targets)
 end
 
 """
-    Bin(T, m::Int)
+    Bin(predictions, targets)
+
+Create bin of `predictions` and corresponding `targets`.
+"""
+function Bin(predictions::AbstractVector{<:AbstractVector{<:Real}},
+             targets::AbstractVector{<:Integer})
+    # compute sum of predictions
+    sum_predictions = sum(predictions)
+
+    # compute counts of targets
+    nclasses = length(predictions[1])
+    counts_targets = counts(targets, nclasses)
+
+    Bin(length(predictions), sum_predictions, counts_targets)
+end
+
+"""
+    Bin{T}(nclasses::Int)
 
 Create empty container that keeps track of the sum of predictions of type `T` and the
-counts of labels of a model with `m` classes.
+counts of targets of a model with `nclasses` classes.
 """
-Bin(::Type{T}, m::Int) where T = Bin(Ref(0), zeros(T, m), zeros(Int, m))
+Bin{T}(nclasses::Int) where {T<:Real} = Bin(0, zeros(T, nclasses), zeros(Int, nclasses))
 
 """
-    adddata!(bin::Bin, predictions, labels)
+    adddata!(bin::Bin, prediction, target)
 
-Update running statistics of the `bin` by integrating additional pair(s) of `prediction`s
-and `label`s.
+Update running statistics of the `bin` by integrating one additional pair of `prediction`s
+and `target`.
 """
-function adddata!(bin::Bin, prediction::AbstractVector{<:Real}, label::Integer)
-    @unpack nsamples, prediction_sum, label_counts = bin
-
-    # check arguments
-    length(prediction) == length(prediction_sum) ||
-        throw(DimensionMismatch("the number of predicted classes is incorrect"))
+function adddata!(bin::Bin, prediction::AbstractVector{<:Real}, target::Integer)
+    @unpack sum_predictions, counts_targets = bin
 
     # update number of samples
-    nsamples[] += 1
+    bin.nsamples += 1
 
     # update sum of predictions
-    prediction_sum .+= prediction
+    sum_predictions .+= prediction
 
-    # update counts of labels
-    if 1 ≤ label ≤ length(label_counts)
-        @inbounds label_counts[label] += 1
+    # update counts of targets
+    if 1 ≤ target ≤ length(counts_targets)
+        @inbounds counts_targets[target] += 1
     end
-
-    nothing
-end
-
-function adddata!(bin::Bin, predictions::AbstractMatrix{<:Real},
-                  labels::AbstractVector{<:Integer})
-    @unpack nsamples, prediction_sum, label_counts = bin
-
-    # check arguments
-    addnclasses, addnsamples = check_size(predictions, labels)
-    addnclasses == length(prediction_sum) ||
-        throw(DimensionMismatch("the number of predicted classes is incorrect"))
-
-    # update number of samples
-    nsamples[] += addnsamples
-
-    # update sum of predictions
-    for p in eachcol(predictions)
-        prediction_sum .+= p
-    end
-
-    # update counts of labels
-    addcounts!(label_counts, labels, 1:addnclasses)
 
     nothing
 end
@@ -102,35 +79,32 @@ end
 # distance computations
 
 """
-    bin_eval(bin::Bin, distance)
+    scaled_evaluate(distance, bin::Bin)
 
-Evaluate `distance` between the average prediction and the distribution of labels in the
+Evaluate `distance` between the average prediction and the distribution of targets in the
 `bin`, multiplied by the number of samples.
 
 The multiplication with the number of samples simplifies the computation of the expected
 miscalibration error (ECE)[@ref].
 """
-function bin_eval(bin::Bin, distance::Union{TotalVariation,Cityblock,Euclidean,SqEuclidean})
-    @unpack nsamples, prediction_sum, label_counts = bin
+function scaled_evaluate(distance::Union{TotalVariation,Cityblock,Euclidean,SqEuclidean},
+                         bin::Bin)
+    @unpack nsamples, sum_predictions, counts_targets = bin
 
-    # compute output type
-    T = typeof(bin_eval_end(distance,
-                            zero(result_type(distance, prediction_sum, label_counts)), 1))
+    # handle empty bins
+    n = iszero(nsamples) ? 1 : nsamples
 
-    # if bin is empty return 0
-    iszero(nsamples[]) && return zero(T)
-
-    # compute distance between sum of predictions and counts of labels
-    d = evaluate(distance, prediction_sum, label_counts)
+    # compute distance between sum of predictions and counts of targets
+    d = evaluate(distance, sum_predictions, counts_targets)
 
     # perform normalization (e.g., in the case of squared Euclidean distance)
-    bin_eval_end(distance, d, nsamples[])::T
+    normalize_distance(distance, d, n)
 end
 
-# normalization is required since the distance is computed between sum of predictions
-# and counts of labels instead of between the mean of predictions and distribution of labels
-# thus in the case of the squared Euclidean distance without normalization, the result
-# would be multiplied by the squared number of samples instead of only the number of
+# Normalization is required since the distance is computed between sum of predictions
+# and counts of targets instead of between the mean of predictions and distribution of
+# targets. Thus in the case of the squared Euclidean distance without normalization, the
+# result would be multiplied by the squared number of samples instead of only the number of
 # samples.
-bin_eval_end(::Union{TotalVariation,Cityblock,Euclidean}, d::Real, ::Int) = d
-bin_eval_end(::SqEuclidean, d::Real, nsamples::Int) = d * inv(nsamples)
+normalize_distance(::Union{TotalVariation,Cityblock,Euclidean}, d::Real, ::Int) = d
+normalize_distance(::SqEuclidean, d::Real, nsamples::Int) = d / nsamples

--- a/src/binning/medianvariance.jl
+++ b/src/binning/medianvariance.jl
@@ -21,66 +21,72 @@ function perform(alg::MedianVarianceBinning,
     nsamples < minsize && error("at least $minsize samples are required")
 
     # check if only trivial binning is possible
-    (nsamples == minsize || maxbins == 1) && return [Bin(predictions, targets)]
+    minsplit = 2 * minsize
+    (nsamples < minsplit || maxbins == 1) && return [Bin(predictions, targets)]
 
     # find dimension with maximum variance
     idxs_predictions = collect(1:nsamples)
-    max_var_predictions, argmax_var_predictions = max_argmax_var(predictions, idxs_predictions)
+    GC.@preserve idxs_predictions begin
+        max_var_predictions, argmax_var_predictions =
+            max_argmax_var(predictions, idxs_predictions)
 
-    # create priority queue and empty set of bins
-    queue = PriorityQueue(
-        (idxs_predictions, argmax_var_predictions) => max_var_predictions,
-        Base.Order.Reverse)
-    bins = Vector{Bin{T}}(undef, 0)
+        # create priority queue and empty set of bins
+        queue = PriorityQueue(
+            (idxs_predictions, argmax_var_predictions) => max_var_predictions,
+            Base.Order.Reverse)
+        bins = Vector{Bin{T}}(undef, 0)
+    
+        nbins = 1
+        while nbins < maxbins && !isempty(queue)
+            # pick the set with the largest variance
+            idxs, argmax_var = dequeue!(queue)
 
-    nbins = 1
-    while nbins < maxbins && !isempty(queue)
-        # pick the set with the largest variance
-        idxs, argmax_var = dequeue!(queue)
+            # compute indices of the two subsets when splitting at the median
+            idxsbelow, idxsabove = unsafe_median_split!(idxs, predictions, argmax_var)
 
-        # compute the median along this dimension
-        mid = median(predictions[i][argmax_var] for i in idxs)
+            # add a bin of all indices if one of the subsets is too small
+            # can happen if there are many samples that are equal to the median
+            if length(idxsbelow) < minsize || length(idxsabove) < minsize
+                push!(bins, Bin(predictions[idxs], targets[idxs]))
+                continue
+            end
 
-        # compute indices of the two subsets when splitting at the median
-        idxsbelow = [i for i in idxs if predictions[i][argmax_var] < mid]
-        idxsabove = [i for i in idxs if predictions[i][argmax_var] ≥ mid]
+            for newidxs in (idxsbelow, idxsabove)
+                if length(newidxs) < minsplit
+                    # add a new bin if the subset can not be split further
+                    push!(bins, Bin(predictions[newidxs], targets[newidxs]))
+                else
+                    # otherwise update the queue with the new subsets
+                    max_var_newidxs, argmax_var_newidxs = max_argmax_var(predictions, newidxs)
+                    enqueue!(queue, (newidxs, argmax_var_newidxs), max_var_newidxs)
+                end
+            end
 
-        # if splitting is not possible, just create one new bin
-        if length(idxsbelow) < minsize || length(idxsabove) < minsize
+            # in total one additional bin was created
+            nbins += 1
+        end
+        
+        # add remaining bins
+        while !isempty(queue)
+            # pop queue
+            idxs, _ = dequeue!(queue)
+
+            # create bin
             push!(bins, Bin(predictions[idxs], targets[idxs]))
-            continue
         end
-
-        # otherwise update the queue with the new subsets
-        for newidxs in (idxsbelow, idxsabove)
-            max_var_newidxs, argmax_var_newidxs = max_argmax_var(predictions, newidxs)
-            enqueue!(queue, (newidxs, argmax_var_newidxs), max_var_newidxs)
-        end
-
-        # in total one additional bin was created
-        nbins += 1
     end
 
-    # add remaining bins
-    while !isempty(queue)
-        # pop queue
-        idxs, _ = dequeue!(queue)
-
-        # create bin
-        push!(bins, Bin(predictions[idxs], targets[idxs]))
-    end
-
-    bins::Vector{Bin{T}}
+    bins
 end
 
 function max_argmax_var(x::AbstractVector{<:AbstractVector{<:Real}}, idxs)
     # compute variance along the first dimension
-    maxvar = var(x[idx][1] for idx in idxs)
+    maxvar = unsafe_variance_welford(x, idxs, 1)
 
     maxdim = 1
     for d in 1:length(x[1])
         # compute variance along the d-th dimension
-        vard = var(x[idx][d] for idx in idxs)
+        vard = unsafe_variance_welford(x, idxs, d)
 
         # update current optimum if required
         if vard > maxvar
@@ -92,3 +98,63 @@ function max_argmax_var(x::AbstractVector{<:AbstractVector{<:Real}}, idxs)
     maxvar, maxdim
 end
 
+# use Welford algorithm to compute the biased sample variance
+# taken from: https://github.com/JuliaLang/Statistics.jl/blob/da6057baf849cbc803b952ef7adf979ae3a9f9d2/src/Statistics.jl#L184-L199
+# this function is unsafe since it does not perform any bounds checking
+function unsafe_variance_welford(x::AbstractVector{<:AbstractVector{<:Real}},
+                                 idxs::Vector{Int}, dim::Int)
+    n = length(idxs)
+
+    @inbounds begin
+        M = x[idxs[1]][dim] / 1
+        S = zero(M)
+        for i in 2:n
+            idx = idxs[i]
+            value = x[idx][dim]
+
+            new_M = M + (value - M) / i
+            S += (value - M) * (value - new_M)
+            M = new_M
+        end
+    end
+
+    return S / n
+end
+
+# this function is unsafe since it leads to undefined behaviour if the
+# outputs are accessed afer `idxs` has been garbage collected 
+function unsafe_median_split!(idxs::Vector{Int},
+                              x::AbstractVector{<:AbstractVector{<:Real}}, dim::Int)
+    n = length(idxs)
+
+    if length(idxs) < 2
+        cutoff = n
+    else
+        # partially sort the indices `idxs` according to the corresponding values in the
+        # `d`th component of`x`
+        m = div(n + 1, 2)
+        partialsort!(idxs, 1:(m + 1); by = idx -> x[idx][dim])
+
+        # check that we actually capture all values ≤ median
+        # the median is `x[m][dim]`` for vectors of odd length
+        # and `(x[m][dim] + x[m + 1][dim]) / 2` for vectors of even length
+        if x[m][dim] < x[m + 1][dim]
+            cutoff = m
+        elseif m + 1 == n
+            cutoff = n
+        else
+            # otherwise we sort the remaining indices
+            otheridxs = unsafe_wrap(Array, pointer(idxs, m + 2), n - m - 1)
+            sort!(otheridxs; by = idx -> x[idx][dim])
+        
+            # then we obtain the last value ≤ median
+            cutoff = m + 1 + searchsortedlast(otheridxs, m; by = idx -> x[idx][dim])
+        end
+    end
+
+    # create two new arrays that refer to the two subsets of indices
+    idxsbelow = unsafe_wrap(Array, pointer(idxs, 1), cutoff)
+    idxsabove = unsafe_wrap(Array, pointer(idxs, cutoff + 1), n - cutoff)
+
+    idxsbelow, idxsabove
+end

--- a/src/binning/medianvariance.jl
+++ b/src/binning/medianvariance.jl
@@ -133,7 +133,10 @@ function unsafe_median_split!(idxs::Vector{Int},
         # partially sort the indices `idxs` according to the corresponding values in the
         # `d`th component of`x`
         m = div(n + 1, 2)
-        partialsort!(idxs, 1:(m + 1); by = idx -> x[idx][dim])
+        f = let x=x, dim=dim
+            idx -> x[idx][dim]
+        end
+        partialsort!(idxs, 1:(m + 1); by = f)
 
         # check that we actually capture all values ≤ median
         # the median is `x[m][dim]`` for vectors of odd length
@@ -145,10 +148,10 @@ function unsafe_median_split!(idxs::Vector{Int},
         else
             # otherwise we sort the remaining indices
             otheridxs = unsafe_wrap(Array, pointer(idxs, m + 2), n - m - 1)
-            sort!(otheridxs; by = idx -> x[idx][dim])
+            sort!(otheridxs; by = f)
         
             # then we obtain the last value ≤ median
-            cutoff = m + 1 + searchsortedlast(otheridxs, m; by = idx -> x[idx][dim])
+            cutoff = m + 1 + searchsortedlast(otheridxs, m; by = f)
         end
     end
 

--- a/src/binning/medianvariance.jl
+++ b/src/binning/medianvariance.jl
@@ -1,89 +1,94 @@
 struct MedianVarianceBinning <: AbstractBinningAlgorithm
-    minsplit::Int
+    minsize::Int
     maxbins::Int
+
+    function MedianVarianceBinning(minsize, maxbins)
+        maxbins ≥ 1 || error("maximum number of bins must be positive")
+
+        new(minsize, maxbins)
+    end
 end
 
-MedianVarianceBinning() = MedianVarianceBinning(10)
-MedianVarianceBinning(minsplit::Int) = MedianVarianceBinning(minsplit, typemax(Int))
+MedianVarianceBinning(minsize::Int = 10) = MedianVarianceBinning(minsize, typemax(Int))
 
-function perform(alg::MedianVarianceBinning, predictions::AbstractMatrix{<:Real},
-                 labels::AbstractVector{<:Integer})
-    @unpack maxbins, minsplit = alg
+function perform(alg::MedianVarianceBinning,
+                 predictions::AbstractVector{<:AbstractVector{T}},
+                 targets::AbstractVector{<:Integer}) where {T<:Real}
+    @unpack minsize, maxbins = alg
 
-    # check arguments
-    nclasses, nsamples = check_size(predictions, labels)
+    # check if binning is not possible
+    nsamples = length(predictions)
+    nsamples < minsize && error("at least $minsize samples are required")
 
-    # check first if binning is possible
-    (nsamples < minsplit || maxbins <= 1) &&
-        return Dict{Int,Bin{eltype(predictions)}}(1 => Bin(predictions, labels))
+    # check if only trivial binning is possible
+    (nsamples == minsize || maxbins == 1) && return [Bin(predictions, targets)]
 
-    # create empty priority queue and set of bins
-    queue = PriorityQueue{Tuple{typeof(predictions),typeof(labels),Int},
-                          Float64}(Base.Order.Reverse)
-    bins = Dict{Int,Bin{eltype(predictions)}}()
+    # find dimension with maximum variance
+    idxs_predictions = collect(1:nsamples)
+    max_var_predictions, argmax_var_predictions = max_argmax_var(predictions, idxs_predictions)
 
-    # add data set to priority queue
-    varfull = vec(var(predictions; dims = 2))
-    maxvar, maxvardim = findmax(varfull)
-    enqueue!(queue, (predictions, labels, maxvardim), maxvar)
+    # create priority queue and empty set of bins
+    queue = PriorityQueue(
+        (idxs_predictions, argmax_var_predictions) => max_var_predictions,
+        Base.Order.Reverse)
+    bins = Vector{Bin{T}}(undef, 0)
+
     nbins = 1
-
     while nbins < maxbins && !isempty(queue)
-        # pick set with largest variance
-        predictions, labels, maxvardim = dequeue!(queue)
+        # pick the set with the largest variance
+        idxs, argmax_var = dequeue!(queue)
 
-        # check if minimum split size is reached
-        nsamples = size(predictions, 2)
+        # compute the median along this dimension
+        mid = median(predictions[i][argmax_var] for i in idxs)
 
-        # compute index of median element
-        mid = median(view(predictions, maxvardim, :))
+        # compute indices of the two subsets when splitting at the median
+        idxsbelow = [i for i in idxs if predictions[i][argmax_var] < mid]
+        idxsabove = [i for i in idxs if predictions[i][argmax_var] ≥ mid]
 
-        # compute indices of subsets
-        idxsbelow = filter(i -> predictions[maxvardim, i] < mid, 1:nsamples)
-        idxsabove = filter(i -> predictions[maxvardim, i] >= mid, 1:nsamples)
-
-        # if splitting is not possible fix remaining partition
-        if isempty(idxsbelow)
-            bins[length(bins)+1] = Bin(predictions[:, idxsabove], labels[idxsabove])
-
-            # there was only one set left, so we are done
-            continue
-        end
-        if isempty(idxsabove)
-            bins[length(bins)+1] = Bin(predictions[:, idxsbelow], labels[idxsbelow])
-
-            # there was only one set left, so we are done
+        # if splitting is not possible, just create one new bin
+        if length(idxsbelow) < minsize || length(idxsabove) < minsize
+            push!(bins, Bin(predictions[idxs], targets[idxs]))
             continue
         end
 
-        # otherwise create subsets and update the queue or list of bins
-        for idxs in (idxsbelow, idxsabove)
-            # create subsets
-            newpredictions = predictions[:, idxs]
-            newlabels = labels[idxs]
-
-            # try to avoid needless calculations
-            if length(newlabels) < minsplit
-                bins[length(bins)+1] = Bin(newpredictions, newlabels)
-            else
-                newvar = vec(var(newpredictions; dims = 2))
-                newmaxvar, newmaxvardim = findmax(newvar)
-                enqueue!(queue, (newpredictions, newlabels, newmaxvardim), newmaxvar)
-            end
-
-            # we created one additional partition in total
-            nbins += 1
+        # otherwise update the queue with the new subsets
+        for newidxs in (idxsbelow, idxsabove)
+            max_var_newidxs, argmax_var_newidxs = max_argmax_var(predictions, newidxs)
+            enqueue!(queue, (newidxs, argmax_var_newidxs), max_var_newidxs)
         end
+
+        # in total one additional bin was created
+        nbins += 1
     end
 
     # add remaining bins
     while !isempty(queue)
         # pop queue
-        predictions, labels = dequeue!(queue)
+        idxs, _ = dequeue!(queue)
 
         # create bin
-        bins[length(bins)+1] = Bin(predictions, labels)
+        push!(bins, Bin(predictions[idxs], targets[idxs]))
     end
 
-    bins
+    bins::Vector{Bin{T}}
 end
+
+function max_argmax_var(x::AbstractVector{<:AbstractVector{<:Real}}, idxs)
+    # compute variance along the first dimension
+    maxvar = var(x[idx][1] for idx in idxs)
+
+    maxdim = 1
+    for d in 1:length(x[1])
+        # compute variance along the d-th dimension
+        vard = var(x[idx][d] for idx in idxs)
+
+        # update current optimum if required
+        if vard > maxvar
+            maxvar = vard
+            maxdim = d
+        end
+    end
+
+    maxvar, maxdim
+end
+

--- a/src/binning/uniform.jl
+++ b/src/binning/uniform.jl
@@ -2,38 +2,42 @@ struct UniformBinning <: AbstractBinningAlgorithm
     nbins::Int
 end
 
-function perform(binning::UniformBinning, predictions::AbstractMatrix{<:Real},
-                 labels::AbstractVector{<:Integer})
+function perform(binning::UniformBinning,
+                 predictions::AbstractVector{<:AbstractVector{T}},
+                 targets::AbstractVector{<:Integer}) where {T<:Real}
+    _perform(binning, predictions, targets, Val(length(predictions[1])))
+end
+
+function _perform(binning::UniformBinning,
+                  predictions::AbstractVector{<:AbstractVector{T}},
+                  targets::AbstractVector{<:Integer}, nclasses::Val{N}) where {T<:Real,N}
+    @unpack nbins = binning
+
     # create empty dictionary of bins
-    T = eltype(predictions)
-    bins = Dict{Int,Bin{T}}()
+    bins = Dict{NTuple{N,Int},Bin{T}}()
 
     # bin all samples
-    nclasses = size(predictions, 1)
-    @inbounds for i in 1:length(labels)
-        prediction = view(predictions, :, i)
-        bin = get!(bins, binid(binning, prediction), Bin(T, nclasses))
-        adddata!(bin, prediction, labels[i])
+    @inbounds for (prediction, target) in zip(predictions, targets)
+        bin = get!(bins, binindex(prediction, nbins, nclasses), Bin{T}(N))
+        adddata!(bin, prediction, target)
     end
 
-    bins
+    collect(Bin{T}, values(bins))
 end
 
-function binid(alg::UniformBinning, prediction::AbstractVector{<:Real})
-    id = 1
-    @inbounds for p in prediction
-        id *= binid(alg, p)
+function binindex(probs::AbstractVector{<:Real}, nbins::Int, ::Val{N})::NTuple{N,Int} where N
+    ntuple(N) do i
+        binindex(probs[i], nbins)
     end
-    id
 end
 
-function binid(alg::UniformBinning, p::Real)
+function binindex(p::Real, nbins::Int)
     # check argument
-    (p < zero(p) || p > one(p)) &&
+    zero(p) ≤ p ≤ one(p) ||
         throw(ArgumentError("predictions must be between 0 and 1"))
 
     # handle special case p = 0
     iszero(p) && return 1
 
-    ceil(alg.nbins * p)
+    ceil(Int, nbins * p)
 end

--- a/src/kernels/matrix.jl
+++ b/src/kernels/matrix.jl
@@ -19,9 +19,6 @@ UniformScalingKernel(kernel) = UniformScalingKernel(1, kernel)
 
 (kernel::UniformScalingKernel)(x, y) = UniformScaling(kernel.λ * kernel.kernel(x, y))
 
-kernel_result_type(kernel::UniformScalingKernel, x, y) =
-    typeof(zero(kernel.λ) * kernel.kernel(zero(eltype(x)), zero(eltype(y))))
-
 # scaling of scalar-valued kernel by diagonal matrix
 struct DiagonalKernel{V<:AbstractVector{<:Real},K} <: MatrixKernel
     diag::V
@@ -39,6 +36,3 @@ DiagonalKernel(diag::AbstractVector{<:Real}, kernel) =
     DiagonalKernel{typeof(diag),typeof(kernel)}(diag, kernel)
 
 (kernel::DiagonalKernel)(x, y) = Diagonal(kernel.diag .* kernel.kernel(x, y))
-
-kernel_result_type(kernel::DiagonalKernel, x, y) =
-    typeof(zero(eltype(kernel.diag)) * kernel.kernel(zero(eltype(x)), zero(eltype(y))))

--- a/src/skce/generic.jl
+++ b/src/skce/generic.jl
@@ -3,12 +3,6 @@ abstract type SKCE <: CalibrationErrorEstimator end
 # kernel used by the estimator
 kernel(skce::SKCE) = skce.kernel
 
-# result type
-function skce_result_type(skce::SKCE, predictions::AbstractMatrix{<:Real})
-    s = zero(eltype(predictions))
-    eltype(s^2 * zero(kernel_result_type(kernel(skce), s, s)))
-end
-
 """
     skce_kernel(k, p, y, p̃, ỹ)
 
@@ -22,6 +16,8 @@ of the squared kernel calibration error for the matrix-valued kernel `k` and pre
 This method assumes that `p`, `p̃`, `y`, and `ỹ` are valid and specified correctly, and
 does not perform any checks.
 """
+function skce_kernel end
+
 function skce_kernel(kernel::UniformScalingKernel, p::AbstractVector{<:Real},
                      y::Integer, p̃::AbstractVector{<:Real}, ỹ::Integer)
     @unpack λ = kernel

--- a/test/binning/medianvariance.jl
+++ b/test/binning/medianvariance.jl
@@ -2,21 +2,27 @@ using CalibrationErrors, Distributions, StatsBase
 using CalibrationErrors: perform
 
 using Random
+using Test
 
 Random.seed!(1234)
 
 @testset "Simple example ($nclasses classes)" for nclasses in (2, 10, 100)
     nsamples = 1_000
-    predictions = rand(Dirichlet(nclasses, 1), nsamples)
-    labels = rand(1:nclasses, nsamples)
+    dist = Dirichlet(nclasses, 1)
+    predictions = [rand(dist) for _ in 1:nsamples]
+    targets = rand(1:nclasses, nsamples)
 
-    # check number of samples
-    bins = perform(MedianVarianceBinning(10), predictions, labels)
-    for (idx, bin) in bins
-        @test bin.nsamples[] >= 5
-    end
+    # set minimum number of samples
+    bins = @inferred(perform(MedianVarianceBinning(10), predictions, targets))
+    @test all(bin -> bin.nsamples ≥ 10, bins)
+    @test sum(bin -> bin.nsamples, bins) == nsamples
+    @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
+    @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
 
-    # check number of bins
-    bins = perform(MedianVarianceBinning(0, 10), predictions, labels)
-    @test length(bins) <= 10
+    # set maximum number of bins
+    bins = @inferred(perform(MedianVarianceBinning(0, 10), predictions, targets))
+    @test length(bins) ≤ 10
+    @test sum(bin -> bin.nsamples, bins) == nsamples
+    @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
+    @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
 end

--- a/test/binning/uniform.jl
+++ b/test/binning/uniform.jl
@@ -1,47 +1,49 @@
 using CalibrationErrors, Distributions, StatsBase
-using CalibrationErrors: perform, binid
+using CalibrationErrors: perform, binindex
 
 using Random
+using Test
 
 Random.seed!(1234)
 
 @testset "Binning indices" begin
-    @testset "One dimension" begin
-        @test_throws ArgumentError binid(UniformBinning(10), -0.5)
-        @test binid(UniformBinning(10), 0) == 1
-        @test binid(UniformBinning(10), 0.1) == 1
-        @test binid(UniformBinning(10), 1) == 10
-        @test_throws ArgumentError binid(UniformBinning(10), 1.5)
-    end
+    # binindex with scalars
+    @test_throws ArgumentError binindex(-0.5, 10)
+    @test binindex(0, 10) == 1
+    @test binindex(0.1, 10) == 1
+    @test binindex(0.45, 10) == 5
+    @test binindex(1, 10) == 10
+    @test_throws ArgumentError binindex(1.5, 10)
 
-    @testset "Two dimensions" begin
-        @test_throws ArgumentError binid(UniformBinning(10), [-0.5, 0.5])
-        @test binid(UniformBinning(10), [0, 0]) == 1
-        @test binid(UniformBinning(10), [0.1, 0]) == 1
-        @test binid(UniformBinning(10), [1, 1]) == 100
-        @test_throws ArgumentError binid(UniformBinning(10), [1.5, 0.5])
-    end
+    # binindex with vectors
+    @test_throws ArgumentError binindex([-0.5, 0.5], 10, Val(2))
+    @test @inferred(binindex([0, 0], 10, Val(2))) == (1, 1)
+    @test @inferred(binindex([0.1, 0], 10, Val(2))) == (1, 1)
+    @test @inferred(binindex([0.45, 0.55], 10, Val(2))) == (5, 6)
+    @test @inferred(binindex([1, 1], 10, Val(2))) == (10, 10)
+    @test_throws ArgumentError binindex([1.5, 0.5], 10, Val(2))
 end
 
 @testset "Simple example ($nclasses classes)" for nclasses in (2, 10, 100)
-    # sample predictions and labels
+    # sample predictions and targets
     nsamples = 1_000
-    predictions = rand(Dirichlet(nclasses, 1), nsamples)
-    labels = rand(1:nclasses, nsamples)
+    dist = Dirichlet(nclasses, 1)
+    predictions = [rand(dist) for _ in 1:nsamples]
+    targets = rand(1:nclasses, nsamples)
 
     # bin data in bins of uniform width
-    bins = perform(UniformBinning(10), predictions, labels)
+    bins = @inferred(perform(UniformBinning(10), predictions, targets))
 
     # check all bins
-    for (idx, bin) in bins
-        idxs = Int[]
-        for i in axes(predictions, 2)
-            idx == prod(max(1, ceil(10 * p)) for p in view(predictions, :, i)) &&
-                push!(idxs, i)
-        end
+    for bin in bins
+        # compute index of bin from average prediction
+        idx = binindex(bin.sum_predictions ./ bin.nsamples, 10, Val(nclasses))
 
-        @test bin.nsamples[] == length(idxs)
-        @test bin.prediction_sum ≈ vec(sum(predictions[:, idxs], dims=2))
-        @test bin.label_counts ≈ counts(labels[idxs], 1:nclasses)
+        # compute indices of all predictions in the same bin
+        idxs = filter(i -> idx == binindex(predictions[i], 10, Val(nclasses)), 1:nsamples)
+
+        @test bin.nsamples == length(idxs)
+        @test bin.sum_predictions ≈ sum(predictions[idxs])
+        @test bin.counts_targets ≈ counts(targets[idxs], 1:nclasses)
     end
 end

--- a/test/ece.jl
+++ b/test/ece.jl
@@ -1,11 +1,50 @@
 using CalibrationErrors
+using Distributions
+
 using Random
+using Test
 
 Random.seed!(1234)
 
 @testset "Trivial tests" begin
     ece = ECE(UniformBinning(10))
 
-    @test calibrationerror(ece, ([0 1; 1 0], [2, 1])) == 0
-    @test calibrationerror(ece, ([0 0.5 0.5 1; 1 0.5 0.5 0], [2, 2, 1, 1])) == 0
+    @test @inferred(calibrationerror(ece, ([0 1; 1 0], [2, 1]))) == 0
+    @test @inferred(calibrationerror(ece, ([0 0.5 0.5 1; 1 0.5 0.5 0], [2, 2, 1, 1]))) == 0
+end
+
+@testset "Uniform binning: Basic properties" begin
+    ece = ECE(UniformBinning(10))
+    estimates = Vector{Float64}(undef, 1_000)
+
+    for nclasses in (2, 10, 100)
+        dist = Dirichlet(nclasses, 1)
+        
+        for i in 1:length(estimates)
+            predictions = [rand(dist) for _ in 1:20]
+            targets = [rand(Categorical(p)) for p in predictions]
+
+            estimates[i] = calibrationerror(ece, predictions, targets)
+        end
+
+        @test all(x -> zero(x) < x < one(x), estimates)
+    end
+end
+
+@testset "Median variance binning: Basic properties" begin
+    ece = ECE(MedianVarianceBinning(10))
+    estimates = Vector{Float64}(undef, 1_000)
+
+    for nclasses in (2, 10, 100)
+        dist = Dirichlet(nclasses, 1)
+        
+        for i in 1:length(estimates)
+            predictions = [rand(dist) for _ in 1:20]
+            targets = [rand(Categorical(p)) for p in predictions]
+
+            estimates[i] = calibrationerror(ece, predictions, targets)
+        end
+
+        @test all(x -> zero(x) < x < one(x), estimates)
+    end
 end

--- a/test/kernels/matrix.jl
+++ b/test/kernels/matrix.jl
@@ -1,5 +1,7 @@
 using CalibrationErrors
+
 using LinearAlgebra
+using Test
 
 const x1, y1 = 1, 3
 const x2, y2 = [1, -1], [2, 1]

--- a/test/kernels/scalar.jl
+++ b/test/kernels/scalar.jl
@@ -1,4 +1,7 @@
-using CalibrationErrors, Distances
+using CalibrationErrors
+using Distances
+
+using Test
 
 const x1, y1 = 1, 3
 const x2, y2 = [1, -1], [2, 1]

--- a/test/skce/biased.jl
+++ b/test/skce/biased.jl
@@ -1,11 +1,35 @@
 using CalibrationErrors
+using Distributions
+
+using Random
+using Test
+
+Random.seed!(1234)
 
 @testset "Two-dimensional example" begin
     skce = BiasedSKCE(UniformScalingKernel(4, SquaredExponentialKernel(2)))
 
     # only two predictions, i.e., one term in the estimator
-    @test calibrationerror(skce, ([1 0; 0 1], [1, 2])) ≈ 0
-    @test calibrationerror(skce, ([1 0; 0 1], [1, 1])) ≈ 2
-    @test calibrationerror(skce, ([1 0; 0 1], [2, 1])) ≈ 4 - 4 * exp(-4)
-    @test calibrationerror(skce, ([1 0; 0 1], [2, 2])) ≈ 2
+    @test @inferred(calibrationerror(skce, ([1 0; 0 1], [1, 2]))) ≈ 0
+    @test @inferred(calibrationerror(skce, [1 0; 0 1], [1, 1])) ≈ 2
+    @test @inferred(calibrationerror(skce, [[1, 0], [0, 1]], [2, 1])) ≈ 4 - 4 * exp(-4)
+    @test @inferred(calibrationerror(skce, ([1 0; 0 1], [2, 2]))) ≈ 2
+end
+
+@testset "Basic properties" begin
+    skce = BiasedSKCE(UniformScalingKernel(ExponentialKernel(0.1)))
+    estimates = Vector{Float64}(undef, 1_000)
+
+    for nclasses in (2, 10, 100)
+        dist = Dirichlet(nclasses, 1)
+        
+        for i in 1:length(estimates)
+            predictions = [rand(dist) for _ in 1:20]
+            targets = [rand(Categorical(p)) for p in predictions]
+
+            estimates[i] = calibrationerror(skce, predictions, targets)
+        end
+
+        @test all(x -> x > zero(x), estimates)
+    end
 end

--- a/test/skce/unbiased.jl
+++ b/test/skce/unbiased.jl
@@ -1,21 +1,68 @@
 using CalibrationErrors
+using Distributions
+
+using Random
+using Statistics
+using Test
+
+Random.seed!(1234)
 
 @testset "Quadratic: Two-dimensional example" begin
     skce = QuadraticUnbiasedSKCE(UniformScalingKernel(4, SquaredExponentialKernel(2)))
 
     # only two predictions, i.e., one term in the estimator
-    @test calibrationerror(skce, ([1 0; 0 1], [1, 2])) ≈ 0
-    @test calibrationerror(skce, ([1 0; 0 1], [1, 1])) ≈ 0
-    @test calibrationerror(skce, ([1 0; 0 1], [2, 1])) ≈ -8 * exp(-4)
-    @test calibrationerror(skce, ([1 0; 0 1], [2, 2])) ≈ 0
+    @test @inferred(calibrationerror(skce, ([1 0; 0 1], [1, 2]))) ≈ 0
+    @test @inferred(calibrationerror(skce, [1 0; 0 1], [1, 1])) ≈ 0
+    @test @inferred(calibrationerror(skce, [[1, 0], [0, 1]], [2, 1])) ≈ -8 * exp(-4)
+    @test @inferred(calibrationerror(skce, ([1 0; 0 1], [2, 2]))) ≈ 0
+end
+
+@testset "Quadratic: Basic properties" begin
+    skce = QuadraticUnbiasedSKCE(UniformScalingKernel(ExponentialKernel(0.1)))
+    estimates = Vector{Float64}(undef, 1_000)
+
+    for nclasses in (2, 10, 100)
+        dist = Dirichlet(nclasses, 1)
+        
+        for i in 1:length(estimates)
+            predictions = [rand(dist) for _ in 1:20]
+            targets = [rand(Categorical(p)) for p in predictions]
+
+            estimates[i] = calibrationerror(skce, predictions, targets)
+        end
+
+        @test any(x -> x > zero(x), estimates)
+        @test any(x -> x < zero(x), estimates)
+        @test mean(estimates) ≈ 0 atol=1e-3
+    end
 end
 
 @testset "Linear: Two-dimensional example" begin
     skce = LinearUnbiasedSKCE(UniformScalingKernel(4, SquaredExponentialKernel(2)))
 
     # only two predictions, i.e., one term in the estimator
-    @test calibrationerror(skce, ([1 0; 0 1], [1, 2])) ≈ 0
-    @test calibrationerror(skce, ([1 0; 0 1], [1, 1])) ≈ 0
-    @test calibrationerror(skce, ([1 0; 0 1], [2, 1])) ≈ -8 * exp(-4)
-    @test calibrationerror(skce, ([1 0; 0 1], [2, 2])) ≈ 0
+    @test @inferred(calibrationerror(skce, ([1 0; 0 1], [1, 2]))) ≈ 0
+    @test @inferred(calibrationerror(skce, [1 0; 0 1], [1, 1])) ≈ 0
+    @test @inferred(calibrationerror(skce, [[1, 0], [0, 1]], [2, 1])) ≈ -8 * exp(-4)
+    @test @inferred(calibrationerror(skce, ([1 0; 0 1], [2, 2]))) ≈ 0
+end
+
+@testset "Linear: Basic properties" begin
+    skce = LinearUnbiasedSKCE(UniformScalingKernel(ExponentialKernel(0.1)))
+    estimates = Vector{Float64}(undef, 1_000)
+
+    for nclasses in (2, 10, 100)
+        dist = Dirichlet(nclasses, 1)
+        
+        for i in 1:length(estimates)
+            predictions = [rand(dist) for _ in 1:20]
+            targets = [rand(Categorical(p)) for p in predictions]
+
+            estimates[i] = calibrationerror(skce, predictions, targets)
+        end
+
+        @test any(x -> x > zero(x), estimates)
+        @test any(x -> x < zero(x), estimates)
+        @test mean(estimates) ≈ 0 atol=5e-3
+    end
 end


### PR DESCRIPTION
This PR is a major update of the initial version of CalibrationErrors, maybe the term "rewrite" is actually more accurate.

Internally now we only work with vectors of (vector-valued) predictions and vectors of (integer-valued) targets, instead of matrix-valued predictions. There are two main reasons for this change: first of all, it allows us to avoid a huge amount of allocations caused by `view` in the evaluation of the kernel method (see benchmarks below), and secondly it feels a lot more natural in the case of regression, where we will then deal with vectors of distributions (I intend to add support for distributions within the next weeks). BTW the longer I think about it, the more convinced I am that Distributions should switch to sampling vectors of vectors for multivariate distributions as well, similar to the behaviour of `rand` in base - IMO it would be more consistent and also simplify our tests a bit :stuck_out_tongue: For now I kept the support for matrix-valued predictions and tuples of predictions and targets in `calibrationerror`, hence so far this change is mostly internal.

A second internal change is the removal of all `*_result_type` methods. IMO there is no need to compute these, we should just let the compiler figure out return types.

The median variance binning scheme is modified slightly. Instead of setting a minimum number of samples which is still split we now set a minimum number of samples in each bin. This feels more natural.

Additionally, this update includes a fix for a (quite embarrassing) bug in the implementation of ECE with bins of uniform width: in the initial version of this package, different bins were potentially merged due to a collision of bin indices. I dropped the custom enumeration of bins and switched to keys of type `NTuple{N,Int}` instead, also to avoid integer overflow in high-dimensional cases. Unfortunately this leads to a quite significant performance regression (see below). I'll further investigate if this could be avoided by a tree(-like) implementation, similar to the one for the median variance binning scheme (for which this PR gives a major performance boost and a largely reduced number of allocations).

I ran some benchmarks (should have done this already some time ago :stuck_out_tongue:), and compared the performance on master with this PR:
```julia
using CalibrationErrors
using Distributions
using BenchmarkTools

using CalibrationErrors: _calibrationerror

using Random

ece_uniform(predictions, targets) = _calibrationerror(ECE(UniformBinning(10)), predictions, targets)
ece_medianvariance(predictions, targets) = _calibrationerror(ECE(MedianVarianceBinning(10)), predictions, targets)
skceb(predictions, targets) = _calibrationerror(BiasedSKCE(UniformScalingKernel(ExponentialKernel(0.1))), predictions, targets)
skceuq(predictions, targets) = _calibrationerror(QuadraticUnbiasedSKCE(UniformScalingKernel(ExponentialKernel(0.1))), predictions, targets)
skceul(predictions, targets) = _calibrationerror(LinearUnbiasedSKCE(UniformScalingKernel(ExponentialKernel(0.1))), predictions, targets)

function benchmark(predictions, targets)
    @btime ece_uniform($predictions, $targets)
    @btime ece_medianvariance($predictions, $targets)
    @btime skceb($predictions, $targets)
    @btime skceuq($predictions, $targets)
    @btime skceul($predictions, $targets)

    nothing
end

function benchmark_new(nclasses; α = 1, N = 200)
    Random.seed!(1234)

    dist = Dirichlet(nclasses, α)
    predictions = [rand(dist) for _ in 1:N]
    targets = [rand(Categorical(prediction)) for prediction in predictions]

    benchmark(predictions, targets)
end

function benchmark_old(nclasses; α = 1, N = 200)
    Random.seed!(1234)

    dist = Dirichlet(nclasses, α)
    predictions = rand(dist, N)
    targets = [rand(Categorical(predictions[:, i])) for i in 1:N]

    benchmark(predictions, targets)
end
```
On master I get
```julia
julia> benchmark_old(10);
  38.686 μs (1408 allocations: 89.55 KiB)
  2.013 ms (6397 allocations: 286.08 KiB)
  1.116 ms (20100 allocations: 942.19 KiB)
  1.089 ms (20099 allocations: 942.14 KiB)
  6.134 μs (200 allocations: 9.38 KiB)

julia> benchmark_old(100);
  97.740 μs (1405 allocations: 375.67 KiB)
  13.827 ms (6387 allocations: 1.05 MiB)
  1.552 ms (20100 allocations: 942.19 KiB)
  1.520 ms (20099 allocations: 942.14 KiB)
  9.087 μs (200 allocations: 9.38 KiB)

julia> benchmark_old(1_000);
  956.024 μs (1405 allocations: 3.13 MiB)
  58.996 ms (6481 allocations: 8.79 MiB)
  5.917 ms (20100 allocations: 942.19 KiB)
  5.886 ms (20099 allocations: 942.14 KiB)
  40.748 μs (200 allocations: 9.38 KiB)
```
whereas with this PR I obtain:
```julia
julia> benchmark_new(10);
  85.826 μs (1218 allocations: 218.19 KiB)
  159.302 μs (404 allocations: 46.05 KiB)
  924.360 μs (0 allocations: 0 bytes)
  891.803 μs (0 allocations: 0 bytes)
  4.541 μs (0 allocations: 0 bytes)

julia> benchmark_new(100);
  793.028 μs (1807 allocations: 725.64 KiB)
  509.829 μs (349 allocations: 187.06 KiB)
  1.449 ms (0 allocations: 0 bytes)
  1.413 ms (0 allocations: 0 bytes)
  7.449 μs (0 allocations: 0 bytes)

julia> benchmark_new(1_000);
  7.672 ms (2209 allocations: 9.44 MiB)
  4.845 ms (386 allocations: 1.56 MiB)
  5.704 ms (0 allocations: 0 bytes)
  5.615 ms (0 allocations: 0 bytes)
  37.265 μs (0 allocations: 0 bytes)
```
The performance regression for ECE with bins of uniform width is very unfortunate, but otherwise I'm quite happy with the results. In particular the timings for ECE with median variance binning look a lot better :slightly_smiling_face: 

*Edit:* Updated benchmarks.