### PR TITLE
Fix bug in dynamic binning

### DIFF
--- a/src/binning/medianvariance.jl
+++ b/src/binning/medianvariance.jl
@@ -3,6 +3,7 @@ struct MedianVarianceBinning <: AbstractBinningAlgorithm
     maxbins::Int
 
     function MedianVarianceBinning(minsize, maxbins)
+        minsize ≥ 1 || error("minimum number of samples must be positive")
         maxbins ≥ 1 || error("maximum number of bins must be positive")
 
         new(minsize, maxbins)
@@ -65,7 +66,7 @@ function perform(alg::MedianVarianceBinning,
             # in total one additional bin was created
             nbins += 1
         end
-        
+
         # add remaining bins
         while !isempty(queue)
             # pop queue
@@ -139,9 +140,9 @@ function unsafe_median_split!(idxs::Vector{Int},
         partialsort!(idxs, 1:(m + 1); by = f)
 
         # check that we actually capture all values ≤ median
-        # the median is `x[m][dim]`` for vectors of odd length
-        # and `(x[m][dim] + x[m + 1][dim]) / 2` for vectors of even length
-        if x[m][dim] < x[m + 1][dim]
+        # the median is `x[idxs[m]][dim]`` for vectors of odd length
+        # and `(x[idxs[m]][dim] + x[idxs[m + 1]][dim]) / 2` for vectors of even length
+        if x[idxs[m]][dim] < x[idxs[m + 1]][dim]
             cutoff = m
         elseif m + 1 == n
             cutoff = n

--- a/test/binning/medianvariance.jl
+++ b/test/binning/medianvariance.jl
@@ -1,28 +1,93 @@
 using CalibrationErrors, Distributions, StatsBase
 using CalibrationErrors: perform
 
+using LinearAlgebra
 using Random
 using Test
 
 Random.seed!(1234)
 
-@testset "Simple example ($nclasses classes)" for nclasses in (2, 10, 100)
+@testset "Constructors" begin
+    @test_throws ErrorException MedianVarianceBinning(-1)
+    @test_throws ErrorException MedianVarianceBinning(0)
+    @test_throws ErrorException MedianVarianceBinning(10, -1)
+    @test_throws ErrorException MedianVarianceBinning(10, 0)
+end
+
+@testset "Basic tests ($nclasses classes)" for nclasses in (2, 10, 100)
     nsamples = 1_000
     dist = Dirichlet(nclasses, 1)
     predictions = [rand(dist) for _ in 1:nsamples]
     targets = rand(1:nclasses, nsamples)
 
     # set minimum number of samples
-    bins = @inferred(perform(MedianVarianceBinning(10), predictions, targets))
-    @test all(bin -> bin.nsamples ≥ 10, bins)
-    @test sum(bin -> bin.nsamples, bins) == nsamples
-    @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
-    @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
+    for minsize in (1, 10, 100, 500, 1_000)
+        bins = @inferred(perform(MedianVarianceBinning(minsize), predictions, targets))
+        @test all(bin -> bin.nsamples ≥ minsize, bins)
+        @test sum(bin -> bin.nsamples, bins) == nsamples
+        @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
+        @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
+    end
 
     # set maximum number of bins
-    bins = @inferred(perform(MedianVarianceBinning(0, 10), predictions, targets))
-    @test length(bins) ≤ 10
-    @test sum(bin -> bin.nsamples, bins) == nsamples
-    @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
-    @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
+    for maxbins in (1, 10, 100, 500, 1_000)
+        bins = @inferred(perform(MedianVarianceBinning(1, maxbins), predictions, targets))
+        @test length(bins) ≤ maxbins
+        @test all(bin -> bin.nsamples ≥ 1, bins)
+        @test sum(bin -> bin.nsamples, bins) == nsamples
+        @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
+        @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
+    end
+end
+
+@testset "Simple example" begin
+    predictions = [[0.4, 0.1, 0.5], [0.5, 0.3, 0.2], [0.3, 0.7, 0.0]]
+    targets = [1, 2, 3]
+    # maximum possible steps in the order they might occur:
+    # first step: [1, 2], [3] -> create bin with [3]
+    # second step: [2], [1] -> create bins with [2] and [1]
+
+    bins = perform(MedianVarianceBinning(1), predictions, targets)
+    @test length(bins) == 3
+    @test all(bin -> bin.nsamples == 1, bins)
+    for (i, idx) in enumerate((3, 2, 1))
+        @test bins[i].sum_predictions == predictions[idx]
+        @test bins[i].counts_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
+    end
+
+    bins = perform(MedianVarianceBinning(2), predictions, targets)
+    @test length(bins) == 1
+    @test bins[1].nsamples == 3
+    @test bins[1].sum_predictions == sum(predictions)
+    @test bins[1].counts_targets == [1, 1, 1]
+
+    predictions = [[0.4, 0.1, 0.5], [0.5, 0.3, 0.2], [0.3, 0.7, 0.0], [0.1, 0.0, 0.9], [0.8, 0.1, 0.1]]
+    targets = [1, 2, 3, 1, 2]
+    # maximum possible steps in the order they might occur:
+    # first step: [2, 3, 5], [1, 4]
+    # second step: [2, 5], [3], [1, 4] -> create bin with [3]
+    # third step:  [2, 5], [1], [4] -> create bins with [1] and [4]
+    # fourth step: [2], [5] -> create bins with [2] and [5]
+
+    bins = perform(MedianVarianceBinning(1), predictions, targets)
+    @test length(bins) == 5
+    @test all(bin -> bin.nsamples == 1, bins)
+    for (i, idx) in enumerate((3, 1, 4, 2, 5))
+        @test bins[i].sum_predictions == predictions[idx]
+        @test bins[i].counts_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
+    end
+
+    bins = perform(MedianVarianceBinning(2), predictions, targets)
+    @test length(bins) == 2
+    for (i, idxs) in enumerate(([2, 3, 5], [1, 4]))
+        @test bins[i].nsamples == length(idxs)
+        @test bins[i].sum_predictions ≈ sum(predictions[idxs])
+        @test bins[i].counts_targets == vec(sum(Matrix{Float64}(I, 3, 3)[:, targets[idxs]]; dims = 2))
+    end
+
+    bins = perform(MedianVarianceBinning(3), predictions, targets)
+    @test length(bins) == 1
+    @test bins[1].nsamples == 5
+    @test bins[1].sum_predictions == sum(predictions)
+    @test bins[1].counts_targets == [2, 2, 1]
 end


### PR DESCRIPTION
https://github.com/devmotion/CalibrationErrors.jl/pull/5 introduced a bug in the implementation of the dynamic binning scheme. It is captured by the significantly extended set of tests. The fix decreases performance only slightly:
```julia
julia> benchmark_new(10);
  85.914 μs (1218 allocations: 218.19 KiB)
  150.216 μs (402 allocations: 45.89 KiB)
  922.917 μs (0 allocations: 0 bytes)
  890.328 μs (0 allocations: 0 bytes)
  4.537 μs (0 allocations: 0 bytes)

julia> benchmark_new(100);
  792.887 μs (1807 allocations: 725.64 KiB)
  565.948 μs (402 allocations: 189.64 KiB)
  1.448 ms (0 allocations: 0 bytes)
  1.413 ms (0 allocations: 0 bytes)
  7.228 μs (0 allocations: 0 bytes)

julia> benchmark_new(1_000);
  7.679 ms (2209 allocations: 9.44 MiB)
  4.895 ms (402 allocations: 1.56 MiB)
  5.698 ms (0 allocations: 0 bytes)
  5.606 ms (0 allocations: 0 bytes)
  37.415 μs (0 allocations: 0 bytes)
```