### PR TITLE
Use online algorithm for computing mean

### DIFF
--- a/src/binning/generic.jl
+++ b/src/binning/generic.jl
@@ -3,29 +3,26 @@ abstract type AbstractBinningAlgorithm end
 mutable struct Bin{T<:Real}
     """Number of samples."""
     nsamples::Int
-    """Sum of predictions."""
-    sum_predictions::Vector{T}
-    """Counts of targets."""
-    counts_targets::Vector{Int}
+    """Mean of predictions."""
+    mean_predictions::Vector{T}
+    """Proportions of targets."""
+    proportions_targets::Vector{T}
 
-    function Bin{T}(nsamples::Int, sum_predictions::Vector{T},
-                    counts_targets::Vector{Int}) where {T}
+    function Bin{T}(nsamples::Int, mean_predictions::Vector{T},
+                    proportions_targets::Vector{T}) where {T}
         nsamples ≥ 0 || throw(ArgumentError("the number of samples must be non-negative"))
-        nclasses = length(sum_predictions)
+        nclasses = length(mean_predictions)
         nclasses > 1 || throw(ArgumentError("the number of classes must be greater than 1"))
-        nclasses == length(counts_targets) ||
+        nclasses == length(proportions_targets) ||
             throw(DimensionMismatch("the number of predicted classes has to be equal to the number of classes"))
 
-        new{T}(nsamples, sum_predictions, counts_targets)
+        new{T}(nsamples, mean_predictions, proportions_targets)
     end
 end
 
-Bin(nsamples::Int, sum_predictions::Vector{<:Real}, counts_targets::Vector{Int}) =
-    Bin{eltype(sum_predictions)}(nsamples, sum_predictions, counts_targets)
-
-function Bin(nsamples::Int, sum_predictions::AbstractVector{<:Real},
-             counts_targets::Vector{Int})
-    Bin(nsamples, convert(Vector, sum_predictions), counts_targets)
+function Bin(nsamples::Int, mean_predictions::Vector{T},
+             proportions_targets::Vector{T}) where {T<:Real}
+    Bin{T}(nsamples, mean_predictions, proportions_targets)
 end
 
 """
@@ -35,23 +32,33 @@ Create bin of `predictions` and corresponding `targets`.
 """
 function Bin(predictions::AbstractVector{<:AbstractVector{<:Real}},
              targets::AbstractVector{<:Integer})
-    # compute sum of predictions
-    sum_predictions = sum(predictions)
+    # compute mean of predictions
+    mean_predictions = mean(predictions)
 
-    # compute counts of targets
+    # compute proportion of targets
     nclasses = length(predictions[1])
-    counts_targets = counts(targets, nclasses)
+    proportions_targets = proportions(targets, nclasses)
 
-    Bin(length(predictions), sum_predictions, counts_targets)
+    Bin(length(predictions), mean_predictions, proportions_targets)
 end
 
 """
-    Bin{T}(nclasses::Int)
+    Bin(prediction, target)
 
-Create empty container that keeps track of the sum of predictions of type `T` and the
-counts of targets of a model with `nclasses` classes.
+Create bin of a signle `prediction` and corresponding `target`.
 """
-Bin{T}(nclasses::Int) where {T<:Real} = Bin(0, zeros(T, nclasses), zeros(Int, nclasses))
+function Bin(prediction::AbstractVector{<:Real}, target::Integer)
+    # compute mean of predictions
+    mean_predictions = prediction ./ 1
+
+    # compute proportion of targets
+    proportions_targets = similar(mean_predictions)
+    for i in 1:length(proportions_targets)
+        proportions_targets[i] = i == target ? 1 : 0
+    end
+
+    Bin(1, mean_predictions, proportions_targets)
+end
 
 """
     adddata!(bin::Bin, prediction, target)
@@ -60,18 +67,17 @@ Update running statistics of the `bin` by integrating one additional pair of `pr
 and `target`.
 """
 function adddata!(bin::Bin, prediction::AbstractVector{<:Real}, target::Integer)
-    @unpack sum_predictions, counts_targets = bin
+    @unpack mean_predictions, proportions_targets = bin
 
     # update number of samples
-    bin.nsamples += 1
+    nsamples = (bin.nsamples += 1)
 
-    # update sum of predictions
-    sum_predictions .+= prediction
+    # update mean of predictions
+    @. mean_predictions += (prediction - mean_predictions) / nsamples
 
-    # update counts of targets
-    if 1 ≤ target ≤ length(counts_targets)
-        @inbounds counts_targets[target] += 1
-    end
+    # update proportions of targets
+    nclasses = length(proportions_targets)
+    @. proportions_targets += ((1:nclasses == target) - proportions_targets) / nsamples
 
     nothing
 end
@@ -79,32 +85,11 @@ end
 # distance computations
 
 """
-    scaled_evaluate(distance, bin::Bin)
+    evaluate(distance, bin::Bin)
 
-Evaluate `distance` between the average prediction and the distribution of targets in the
-`bin`, multiplied by the number of samples.
-
-The multiplication with the number of samples simplifies the computation of the expected
-miscalibration error (ECE)[@ref].
+Evaluate the `distance` between the average prediction and the distribution of targets in
+the `bin`.
 """
-function scaled_evaluate(distance::Union{TotalVariation,Cityblock,Euclidean,SqEuclidean},
-                         bin::Bin)
-    @unpack nsamples, sum_predictions, counts_targets = bin
-
-    # handle empty bins
-    n = iszero(nsamples) ? 1 : nsamples
-
-    # compute distance between sum of predictions and counts of targets
-    d = evaluate(distance, sum_predictions, counts_targets)
-
-    # perform normalization (e.g., in the case of squared Euclidean distance)
-    normalize_distance(distance, d, n)
+function Distances.evaluate(distance::SemiMetric, bin::Bin)
+    evaluate(distance, bin.mean_predictions, bin.proportions_targets)
 end
-
-# Normalization is required since the distance is computed between sum of predictions
-# and counts of targets instead of between the mean of predictions and distribution of
-# targets. Thus in the case of the squared Euclidean distance without normalization, the
-# result would be multiplied by the squared number of samples instead of only the number of
-# samples.
-normalize_distance(::Union{TotalVariation,Cityblock,Euclidean}, d::Real, ::Int) = d
-normalize_distance(::SqEuclidean, d::Real, nsamples::Int) = d / nsamples

--- a/src/binning/medianvariance.jl
+++ b/src/binning/medianvariance.jl
@@ -35,7 +35,8 @@ function perform(alg::MedianVarianceBinning,
         queue = PriorityQueue(
             (idxs_predictions, argmax_var_predictions) => max_var_predictions,
             Base.Order.Reverse)
-        bins = Vector{Bin{T}}(undef, 0)
+        S = typeof(zero(T) / 1)
+        bins = Vector{Bin{S}}(undef, 0)
     
         nbins = 1
         while nbins < maxbins && !isempty(queue)

--- a/test/binning/medianvariance.jl
+++ b/test/binning/medianvariance.jl
@@ -23,20 +23,29 @@ end
     # set minimum number of samples
     for minsize in (1, 10, 100, 500, 1_000)
         bins = @inferred(perform(MedianVarianceBinning(minsize), predictions, targets))
+
         @test all(bin -> bin.nsamples ≥ minsize, bins)
+        @test all(bin -> sum(bin.mean_predictions) ≈ 1, bins)
+        @test all(bin -> sum(bin.proportions_targets) ≈ 1, bins)
+
         @test sum(bin -> bin.nsamples, bins) == nsamples
-        @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
-        @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
+        @test sum(bin -> bin.nsamples .* bin.mean_predictions, bins) ≈ sum(predictions)
+        @test sum(bin -> bin.nsamples .* bin.proportions_targets, bins) ≈ counts(targets, nclasses)
     end
 
     # set maximum number of bins
     for maxbins in (1, 10, 100, 500, 1_000)
         bins = @inferred(perform(MedianVarianceBinning(1, maxbins), predictions, targets))
+
         @test length(bins) ≤ maxbins
+
         @test all(bin -> bin.nsamples ≥ 1, bins)
+        @test all(bin -> sum(bin.mean_predictions) ≈ 1, bins)
+        @test all(bin -> sum(bin.proportions_targets) ≈ 1, bins)
+
         @test sum(bin -> bin.nsamples, bins) == nsamples
-        @test sum(bin -> bin.sum_predictions, bins) ≈ sum(predictions)
-        @test sum(bin -> bin.counts_targets, bins) == counts(targets, 1:nclasses)
+        @test sum(bin -> bin.nsamples .* bin.mean_predictions, bins) ≈ sum(predictions)
+        @test sum(bin -> bin.nsamples .* bin.proportions_targets, bins) ≈ counts(targets, nclasses)
     end
 end
 
@@ -51,15 +60,15 @@ end
     @test length(bins) == 3
     @test all(bin -> bin.nsamples == 1, bins)
     for (i, idx) in enumerate((3, 2, 1))
-        @test bins[i].sum_predictions == predictions[idx]
-        @test bins[i].counts_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
+        @test bins[i].mean_predictions == predictions[idx]
+        @test bins[i].proportions_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
     end
 
     bins = perform(MedianVarianceBinning(2), predictions, targets)
     @test length(bins) == 1
     @test bins[1].nsamples == 3
-    @test bins[1].sum_predictions == sum(predictions)
-    @test bins[1].counts_targets == [1, 1, 1]
+    @test bins[1].mean_predictions == mean(predictions)
+    @test bins[1].proportions_targets == [1/3, 1/3, 1/3]
 
     predictions = [[0.4, 0.1, 0.5], [0.5, 0.3, 0.2], [0.3, 0.7, 0.0], [0.1, 0.0, 0.9], [0.8, 0.1, 0.1]]
     targets = [1, 2, 3, 1, 2]
@@ -73,21 +82,23 @@ end
     @test length(bins) == 5
     @test all(bin -> bin.nsamples == 1, bins)
     for (i, idx) in enumerate((3, 1, 4, 2, 5))
-        @test bins[i].sum_predictions == predictions[idx]
-        @test bins[i].counts_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
+        @test bins[i].mean_predictions == predictions[idx]
+        @test bins[i].proportions_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
     end
 
     bins = perform(MedianVarianceBinning(2), predictions, targets)
     @test length(bins) == 2
+    @test all(bin -> sum(bin.mean_predictions) ≈ 1, bins)
+    @test all(bin -> sum(bin.proportions_targets) ≈ 1, bins)
     for (i, idxs) in enumerate(([2, 3, 5], [1, 4]))
         @test bins[i].nsamples == length(idxs)
-        @test bins[i].sum_predictions ≈ sum(predictions[idxs])
-        @test bins[i].counts_targets == vec(sum(Matrix{Float64}(I, 3, 3)[:, targets[idxs]]; dims = 2))
+        @test bins[i].mean_predictions ≈ mean(predictions[idxs])
+        @test bins[i].proportions_targets == vec(mean(Matrix{Float64}(I, 3, 3)[:, targets[idxs]]; dims = 2))
     end
 
     bins = perform(MedianVarianceBinning(3), predictions, targets)
     @test length(bins) == 1
     @test bins[1].nsamples == 5
-    @test bins[1].sum_predictions == sum(predictions)
-    @test bins[1].counts_targets == [2, 2, 1]
+    @test bins[1].mean_predictions == mean(predictions)
+    @test bins[1].proportions_targets == [0.4, 0.4, 0.2]
 end


### PR DESCRIPTION
This changes the computation of the averages in the estimation of the ECE and the SKCE to West's algorithm. Moreover, for now I switched to using a sorted vector instead of a `Dict` for creating the uniform bins. In the benchmarks this seems to improve performance (maybe since hashing `NTuple`s is slow?):
```julia
julia> benchmark_new(10);
  55.781 μs (1007 allocations: 145.80 KiB)
  151.047 μs (434 allocations: 50.89 KiB)
  1.031 ms (0 allocations: 0 bytes)
  994.032 μs (0 allocations: 0 bytes)
  5.048 μs (0 allocations: 0 bytes)

julia> benchmark_new(100);
  711.763 μs (1008 allocations: 513.80 KiB)
  572.629 μs (434 allocations: 217.64 KiB)
  1.553 ms (0 allocations: 0 bytes)
  1.516 ms (0 allocations: 0 bytes)
  7.720 μs (0 allocations: 0 bytes)

julia> benchmark_new(1000);
  6.771 ms (1409 allocations: 7.76 MiB)
  4.930 ms (434 allocations: 1.81 MiB)
  5.797 ms (0 allocations: 0 bytes)
  5.704 ms (0 allocations: 0 bytes)
  37.659 μs (0 allocations: 0 bytes)
```
However, I guess this might have to be reevaluated or changed again at some point.