### PR TITLE
Minor fixes

### DIFF
--- a/test/binning/medianvariance.jl
+++ b/test/binning/medianvariance.jl
@@ -53,13 +53,13 @@ end
     predictions = [[0.4, 0.1, 0.5], [0.5, 0.3, 0.2], [0.3, 0.7, 0.0]]
     targets = [1, 2, 3]
     # maximum possible steps in the order they might occur:
-    # first step: [1, 2], [3] -> create bin with [3]
-    # second step: [2], [1] -> create bins with [2] and [1]
+    # first step: [1], [2, 3] -> create bin with [1]
+    # second step: [2], [3] -> create bins with [2] and [3]
 
     bins = perform(MedianVarianceBinning(1), predictions, targets)
     @test length(bins) == 3
     @test all(bin -> bin.nsamples == 1, bins)
-    for (i, idx) in enumerate((3, 2, 1))
+    for (i, idx) in enumerate((1, 2, 3))
         @test bins[i].mean_predictions == predictions[idx]
         @test bins[i].proportions_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
     end
@@ -73,15 +73,15 @@ end
     predictions = [[0.4, 0.1, 0.5], [0.5, 0.3, 0.2], [0.3, 0.7, 0.0], [0.1, 0.0, 0.9], [0.8, 0.1, 0.1]]
     targets = [1, 2, 3, 1, 2]
     # maximum possible steps in the order they might occur:
-    # first step: [2, 3, 5], [1, 4]
-    # second step: [2, 5], [3], [1, 4] -> create bin with [3]
-    # third step:  [2, 5], [1], [4] -> create bins with [1] and [4]
-    # fourth step: [2], [5] -> create bins with [2] and [5]
+    # first step: [3, 5], [1, 2, 4]
+    # second step: [5], [3], [1, 2, 4] -> create bins with [5] and [3]
+    # third step:  [2], [1, 4] -> create bin with [2]
+    # fourth step: [1], [4] -> create bins with [1] and [4]
 
     bins = perform(MedianVarianceBinning(1), predictions, targets)
     @test length(bins) == 5
     @test all(bin -> bin.nsamples == 1, bins)
-    for (i, idx) in enumerate((3, 1, 4, 2, 5))
+    for (i, idx) in enumerate((5, 3, 2, 1, 4))
         @test bins[i].mean_predictions == predictions[idx]
         @test bins[i].proportions_targets == Matrix{Float64}(I, 3, 3)[:, targets[idx]]
     end
@@ -90,7 +90,7 @@ end
     @test length(bins) == 2
     @test all(bin -> sum(bin.mean_predictions) ≈ 1, bins)
     @test all(bin -> sum(bin.proportions_targets) ≈ 1, bins)
-    for (i, idxs) in enumerate(([2, 3, 5], [1, 4]))
+    for (i, idxs) in enumerate(([3, 5], [1, 2, 4]))
         @test bins[i].nsamples == length(idxs)
         @test bins[i].mean_predictions ≈ mean(predictions[idxs])
         @test bins[i].proportions_targets == vec(mean(Matrix{Float64}(I, 3, 3)[:, targets[idxs]]; dims = 2))


### PR DESCRIPTION
This PR simplifies the dynamic binning scheme by forming bins of samples `< median` and `>= median` instead of `<= median` and `> median` (actually, this changes the behaviour back to how it was in 0.1). The simple benchmark yields:
```julia
julia> benchmark_new(10);  
  55.489 μs (1007 allocations: 145.80 KiB)
  145.770 μs (434 allocations: 50.89 KiB)
  1.035 ms (0 allocations: 0 bytes)
  998.792 μs (0 allocations: 0 bytes)
  5.059 μs (0 allocations: 0 bytes)

julia> benchmark_new(100);
  712.345 μs (1008 allocations: 513.80 KiB)
  564.525 μs (434 allocations: 217.64 KiB)
  1.555 ms (0 allocations: 0 bytes)
  1.516 ms (0 allocations: 0 bytes)
  7.706 μs (0 allocations: 0 bytes)

julia> benchmark_new(1000);
  6.883 ms (1409 allocations: 7.76 MiB)
  4.924 ms (434 allocations: 1.81 MiB)
  5.799 ms (0 allocations: 0 bytes)
  5.709 ms (0 allocations: 0 bytes)
  37.499 μs (0 allocations: 0 bytes)
```